### PR TITLE
bugfix: remove sunflower_plains from spawn_biomes

### DIFF
--- a/src/main/java/com/seedfinding/mcfeature/misc/SpawnPoint.java
+++ b/src/main/java/com/seedfinding/mcfeature/misc/SpawnPoint.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class SpawnPoint extends Feature<Feature.Config, SpawnPoint.Data> {
 	public static final List<Biome> SPAWN_BIOMES = Arrays.asList(
-		Biomes.PLAINS, Biomes.SUNFLOWER_PLAINS,
+		Biomes.PLAINS,
 		Biomes.TAIGA, Biomes.TAIGA_HILLS,
 		Biomes.FOREST, Biomes.WOODED_HILLS,
 		Biomes.JUNGLE, Biomes.JUNGLE_HILLS


### PR DESCRIPTION
for example these seeds had completely wrong spawns:
67352081934728881
-4881610696750904387
8287316889342153968