### PR TITLE
Fix stacking enchants

### DIFF
--- a/src/main/java/com/seedfinding/mcfeature/loot/function/EnchantWithLevelsFunction.java
+++ b/src/main/java/com/seedfinding/mcfeature/loot/function/EnchantWithLevelsFunction.java
@@ -132,7 +132,7 @@ public class EnchantWithLevelsFunction extends EnchantmentFunction {
 	public ItemStack enchantItem(LootContext random, ItemStack itemStack, int level, boolean isTreasure, boolean isDiscoverable) {
 		List<EnchantmentInstance> list = selectEnchantment(random, itemStack, level, isTreasure, isDiscoverable);
 		if (itemStack.getItem().equalsName(Items.BOOK)){
-			itemStack=new ItemStack(Items.ENCHANTED_BOOK);
+			itemStack = new ItemStack(new Item(Items.ENCHANTED_BOOK.getName()));
 		}
 		for(EnchantmentInstance enchantmentInstance : list) {
 			itemStack.getItem().addEnchantment(new Pair<>(enchantmentInstance.getEnchantment().getName(), enchantmentInstance.getLevel()));


### PR DESCRIPTION
The Stronghold library chest changes the item of the used book ItemStack to the static reference Items.ENCHANTED_BOOK, causing infinitely stacking enchantments.